### PR TITLE
ajout fonction no scroll sur map de la show

### DIFF
--- a/app/javascript/plugins/init_mapbox.js
+++ b/app/javascript/plugins/init_mapbox.js
@@ -40,6 +40,7 @@ const initMapboxShow = () => {
       container: 'map-show',
       style: 'mapbox://styles/mapbox/streets-v10'
     });
+    map.scrollZoom.disable();
     const marker = JSON.parse(mapElement.dataset.markers);
 
 


### PR DESCRIPTION
Hello, je trouvais gênant de pouvoir scroll sur la map de la show, c'était gênant en navigation, j'ai donc retiré le scroll pour que cela soit figé comme une image.