### PR TITLE
changed html so price in form cannot be neg

### DIFF
--- a/app/views/conveyings/new.html.erb
+++ b/app/views/conveyings/new.html.erb
@@ -13,7 +13,7 @@
         <%= f.input :capacity, collection: Conveying::CAPACITIES%>
       </div>
       <div class="col-3 form-group">
-        <%= f.input :price%>
+        <%= f.input :price, input_html: { min: 0 } %>
       </div>
     </div>
     <div class="form-row">


### PR DESCRIPTION
Le prix ne peut plus etre négatif dans le formulaire de cra de convey
        <%= f.input :price, input_html: { min: 0 } %>

<img width="897" alt="Capture d’écran 2020-11-20 à 11 56 56" src="https://user-images.githubusercontent.com/60131956/99792698-c09a7900-2b27-11eb-9da8-f7e25f62ed53.png">
